### PR TITLE
Update get_sessions.sh to remove hardcoded user_uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ Steps to use:
 
 3. Save the `Cookie` value from the Request headers to `reinvent.cookie`. You can get this by copying the header value, copying the full request as curl and pulling out the `-H` value, etc. It should look like `AWSALB=7Sr4u...`; do not save the `Cookie: ` key to the file.
 ß
-4. Run `./get_sessions.sh`; this will create two files, `sessions_YYYY-MM-DDTHHMM.json` and `interests_YYYY-MM-DDTHHMM.json`.
+4. Get the "userUid" from the Response returned at the "/user" http call at Developer Tools.
 
-5. Install node modules
+6. Run `./get_sessions.sh "<userUid>"` passing the userUid; this will create two files, `sessions_YYYY-MM-DDTHHMM.json` and `interests_YYYY-MM-DDTHHMM.json`.
+
+7. Install node modules
 
     ```bash
     npm install
     ```
     
-6. Execute the script to generate the `.ics` files.
+8. Execute the script to generate the `.ics` files.
 
    ```bash
    Usage: node sessions-to-ics.js [options] <sessions> <interests>
@@ -44,4 +46,4 @@ Steps to use:
    
    ICS files will be written to the output directory (default `./sessions`).
 
-7. Import the `*.ics` files into the Calendar of your choice.
+9. Import the `*.ics` files into the Calendar of your choice.

--- a/get_sessions.sh
+++ b/get_sessions.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+USER_ID="$1"
+
 if [[ ! -f reinvent.cookie ]]; then
     echo >&2 "Please login to https://hub.reinvent.awsevents.com/attendee-portal/agenda/ and save"
     echo >&2 "all Cookies from the request to ./reinvent.cookie"
@@ -24,7 +26,7 @@ curl -sLf 'https://hub.reinvent.awsevents.com/attendee-portal-api/sessions/list/
 -H 'X-Requested-With: XMLHttpRequest' | jq > "sessions_${now}.json"
 
 
-curl -sLf 'https://hub.reinvent.awsevents.com/attendee-portal-api/events/getUserReservations/?user_uuid=5DE0160B-975D-480A-AE7E-8B96A3581851' \
+curl -sLf "https://hub.reinvent.awsevents.com/attendee-portal-api/events/getUserReservations/?user_uuid=${USER_ID}" \
 -X 'GET' \
 -H 'Accept: application/json, text/plain, */*' \
 -H 'Sec-Fetch-Site: same-origin' \


### PR DESCRIPTION
user_uuid arg was hardcoded at get_sessions.sh script instead be passed as arg for the script to pull data from specific users.
Issue was fixed by adding an arg to pass in the script... Readme page should be updated later to include the instructions on how to grab user id. It can be done by looking at "/users" response json returned in the browser at the Developer Tools