### PR TITLE
mkdir output first

### DIFF
--- a/sessions-to-ics.js
+++ b/sessions-to-ics.js
@@ -243,10 +243,10 @@ function parseSession(session) {
 }
 
 async function exportSessions(options, command) {
-    const {reserved, interests} = await fetchAgenda(options);
     const outputDir = options.outputDir;
-
     fs.mkdirSync(`./${outputDir}`, {recursive: true});
+
+    const {reserved, interests} = await fetchAgenda(options);
 
     if (!options.reservedOnly) {
         const events = {};


### PR DESCRIPTION
Fixes:

```
❯ node sessions-to-ics.js -a
Retrieving agenda ...
Saving raw agenda to sessions/agenda.json
An error occurred: ENOENT: no such file or directory, open 'sessions/agenda.json'
```
