### PR TITLE
fix: Update for 2025 catalog changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/sessions-to-ics.js",
+            "args": [
+                "-a",
+                "-o",
+                "sessions2025"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sessions-to-ics
 
-**Updated for 2024!**
+**Updated for 2025!**
 
 This script exports the re:Invent sessions you've flagged as favorites to iCal (.ics) format.
 
@@ -23,7 +23,7 @@ Steps to use:
 
 2. Open your browser's Developer Tools and go to the Network tab.
 
-3. Go to your AWS re:Invent [Agenda](https://registration.awsevents.com/flow/awsevents/reinvent24/myagenda/page/myagenda). Make sure you're logged in.
+3. Go to the AWS re:Invent [Event Catalog](https://registration.awsevents.com/flow/awsevents/reinvent2025/event-catalog/page/eventCatalog). Make sure you're logged in.
 
 4. Find the `myData` (https://catalog.awsevents.com/api/myData) request in the Network tab of Developer Tools.
 
@@ -31,6 +31,10 @@ Steps to use:
 
    You can copy the full request as a cURL request and find the `-H` values to load into `config.json`. Make sure to
    take only the values and not the `cookie: ` key prefix.
+
+   You may need to ensure 'Cookies' are selected for inclusion in the
+   headers and some browsers may use the `-b` flag for curl to set
+   cookies instead of `-H 'cookie: ...'`.
 
 6. Install node modules
 

--- a/sessions-to-ics.js
+++ b/sessions-to-ics.js
@@ -55,7 +55,7 @@ const fetchAgenda = async (options) => {
                     'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
                     'rfapiprofileid': rfapiprofileid,
                     'rfauthtoken': rfauthtoken,
-                    'rfwidgetid': '2mD9wSl40wp2ViMLVpbqhzk20AkPDb6Z',
+                    'rfwidgetid': 'QNo5ySw8IarY51RBuM1VMy8dhCq2uudd',
                     'cookie': cookie,
                     'origin': 'https://registration.awsevents.com',
                     'priority': 'u=1, i',
@@ -218,13 +218,18 @@ function toTitleCase(str) {
 
 function parseSession(session) {
     const toUnixTime = (d) => DateTime.fromFormat(d, 'yyyy/MM/dd HH:mm:ss', {zone: 'UTC'}).toUnixInteger();
-    const sessionTime = session.times[0];
-    const [venue, ...room] = sessionTime.room.split(' | ');
+    const sessionTime = session.times && session.times.length > 0 ? session.times[0] : {
+        room: 'UNKNOWN | UNKNOWN',
+        capacity: 0,
+        utcStartTime: '2025/11/30 12:00:00',
+        utcEndTime: '2025/11/30 13:00:00'
+    };
+    const [venue, ...room] = sessionTime.room?.split(' | ') ?? ['UNKNOWN', 'UNKNOWN'];
 
     return {
         code: session.code.replace(/\s+/, ''),
         title: session.title,
-        sessionType: toTitleCase(pluralize.singular(getAttribute(session, 'Sessiontypes')[0])),
+        sessionType: toTitleCase(pluralize.singular(getAttribute(session, 'Type')[0])),
         abstract: session.abstract,
         speakers: session.participants?.map((p) => ({
             name: p.fullName,
@@ -232,7 +237,7 @@ function parseSession(session) {
             jobTitle: p.jobTitle
         })),
         topics: getAttribute(session, 'Topic'),
-        areasOfInterest: getAttribute(session, 'Areaofinterest'),
+        areasOfInterest: getAttribute(session, 'AreaofInterest'),
         venue,
         room: room.join(' | '),
         capacity: sessionTime.capacity,


### PR DESCRIPTION
Updates session parsing for 2025 attribute names and adds handling for unscheduled sessions (no `session.times`). Unscheduled sessions will show up on Sunday, 11/30/2025 from 12:00 - 13:00 UTC.